### PR TITLE
Add unit test

### DIFF
--- a/test.js
+++ b/test.js
@@ -50,6 +50,21 @@ test('pipe', (t) => {
   pipe.on('data', (data) => t.alike(data, Buffer.from('hello'))).end('hello')
 })
 
+test('ignore standard streams', (t) => {
+  t.plan(2)
+
+  const subprocess = spawn(os.execPath(), ['test/fixtures/std-pipe.js'], {
+    stdio: 'ignore'
+  })
+
+  subprocess.on('exit', (code, signal) => {
+    t.is(code, 0)
+
+    t.comment('signal = ', signal)
+    t.is(signal, 0)
+  })
+})
+
 test('overlapped', (t) => {
   t.plan(1)
 

--- a/test/fixtures/std-pipe.js
+++ b/test/fixtures/std-pipe.js
@@ -1,0 +1,5 @@
+const Pipe = require('bare-pipe')
+
+new Pipe(0).end('stdin')
+new Pipe(1).end('stdout')
+new Pipe(2).end('stderr')


### PR DESCRIPTION
Bug validation, this triggers internally:

```
Uncaught Error: socket operation on non-socket
    at ReadableState.afterDestroy (file://bare-subprocess/node_modules/streamx/index.js:511:19)
    at Pipe._destroy (file://bare-subprocess/node_modules/bare-pipe/index.js:206:55)
    at Pipe.destroy (file://bare-subprocess/node_modules/bare-stream/index.js:344:11)
    at ReadableState.updateNonPrimary (file://bare-subprocess/node_modules/streamx/index.js:398:16)
    at ReadableState.update (file:///bare-subprocess/node_modules/streamx/index.js:379:71)
    at ReadableState.updateReadNT (file://bare-subprocess/node_modules/streamx/index.js:554:10)
```

And curiously the exit code is been returned as 0 while the signal code doesn't.

