### PR TITLE
Support subprocess IPC

### DIFF
--- a/.lunteignore
+++ b/.lunteignore
@@ -1,1 +1,2 @@
 index.d.ts
+lib/parent.d.ts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bare-subprocess
 
-Native process spawning for JavaScript.
+Native process spawning for JavaScript. Spawn child processes with full control over their stdio, environment, and working directory, and exchange messages with them over an IPC channel.
 
 ```
 npm i bare-subprocess
@@ -17,6 +17,218 @@ const subprocess = spawn('echo', ['hello', 'world'], {
 
 subprocess.on('exit', () => console.log('done'))
 ```
+
+## API
+
+#### `const subprocess = spawn(file[, args][, options])`
+
+Spawn `file` as a new subprocess with the given `args`. Returns a `Subprocess` instance. `args` may be `null` or omitted to spawn with no arguments. If `args` is omitted, the second argument is treated as `options`.
+
+Options include:
+
+```js
+options = {
+  cwd: os.cwd(),
+  env: process.env,
+  stdio: [],
+  shell: false,
+  detached: false,
+  uid: -1,
+  gid: -1,
+  windowsHide: false,
+  windowsVerbatimArguments: false,
+  serialization: 'json'
+}
+```
+
+`stdio` may be an array of slot descriptors or a single string applied to all of `stdin`, `stdout`, and `stderr`. Each slot may be one of:
+
+| Value          | Description                                                                          |
+| -------------- | ------------------------------------------------------------------------------------ |
+| `'pipe'`       | Open a pipe between parent and child.                                                |
+| `'overlapped'` | Like `'pipe'` but opens the pipe in overlapped mode on Windows.                      |
+| `'inherit'`    | Inherit the parent's corresponding file descriptor (or `'ignore'` for fds beyond 2). |
+| `'ignore'`     | Do not open the file descriptor in the child.                                        |
+| `'ipc'`        | Open an IPC channel between parent and child. At most one slot may use this.         |
+
+`serialization` selects how IPC messages are framed:
+
+| Mode         | Description                                                                                           |
+| ------------ | ----------------------------------------------------------------------------------------------------- |
+| `'json'`     | Newline-delimited JSON. Only JSON-serializable values are supported. Default.                         |
+| `'advanced'` | Length-prefixed structured clone, via `bare-structured-clone`. Supports `Date`, `Map`, `Buffer`, etc. |
+| `'binary'`   | Raw pipe with no framing. `subprocess.channel` is `undefined`; use `subprocess.stdio[fd]` directly.   |
+
+`shell` may be a string identifying the shell to use, or `true` to use the platform default (`/bin/sh`, `/system/bin/sh` on Android, or `cmd.exe` on Windows).
+
+#### `const result = spawnSync(file[, args][, options])`
+
+Synchronously spawn `file` and wait for it to exit. Returns an object:
+
+```js
+result = {
+  pid,
+  status,
+  signal,
+  output,
+  stdout,
+  stderr,
+  error
+}
+```
+
+Accepts all `spawn` options plus:
+
+```js
+options = {
+  input: null,
+  maxBuffer: 1024 * 1024
+}
+```
+
+`input` is written to the child's `stdin` before it starts. `maxBuffer` is the size of the buffer allocated to capture each `'pipe'` stdio slot.
+
+### `class Subprocess`
+
+The handle returned by `spawn`. Extends `EventEmitter`.
+
+#### `subprocess.pid`
+
+The process ID of the child.
+
+#### `subprocess.spawnfile`
+
+The file that was spawned.
+
+#### `subprocess.spawnargs`
+
+The arguments the child was spawned with.
+
+#### `subprocess.stdio`
+
+An array of `bare-pipe` instances corresponding to the configured stdio slots. Slots configured as `'inherit'`, `'ignore'`, or backed by an inherited fd are `null`.
+
+#### `subprocess.stdin`
+
+Convenience accessor for `subprocess.stdio[0]`.
+
+#### `subprocess.stdout`
+
+Convenience accessor for `subprocess.stdio[1]`.
+
+#### `subprocess.stderr`
+
+Convenience accessor for `subprocess.stdio[2]`.
+
+#### `subprocess.exitCode`
+
+The exit code of the child, or `null` if the child has not exited or was terminated by a signal.
+
+#### `subprocess.signalCode`
+
+The name of the signal the child was terminated with, or `null`.
+
+#### `subprocess.killed`
+
+`true` if `subprocess.kill()` has been called, otherwise `false`.
+
+#### `subprocess.connected`
+
+`true` while an IPC channel exists between parent and child.
+
+#### `subprocess.channel`
+
+The `SubprocessChannel` instance backing the IPC channel, or `undefined` when no channel exists. For `serialization: 'binary'`, this is always `undefined`.
+
+#### `subprocess.ref()`
+
+#### `subprocess.unref()`
+
+Reference or unreference the subprocess and its stdio pipes against the event loop.
+
+#### `subprocess.kill([signum])`
+
+Send a signal to the child. `signum` may be a signal number or a name (e.g. `'SIGTERM'`). Defaults to `SIGTERM`.
+
+#### `subprocess.send(message[, handle][, callback])`
+
+Send `message` to the child over the IPC channel. `handle` may be a `bare-pipe` `Pipe` or a `bare-tcp` `Socket` to transfer ownership of along with the message. `callback` is invoked with `(err)` after the message has been written.
+
+Returns `true` if the message was queued for transmission, or `false` if no IPC channel exists or the channel has been disconnected. Throws synchronously if the message cannot be serialized or exceeds the maximum frame size.
+
+#### `subprocess.disconnect()`
+
+Close the IPC channel. A `'disconnect'` event is emitted once the channel is fully closed.
+
+#### `event: 'exit'`
+
+Emitted with `(exitCode, signalCode)` when the child exits.
+
+#### `event: 'close'`
+
+Emitted with `(exitCode, signalCode)` when the child has exited and all stdio pipes have closed.
+
+#### `event: 'message'`
+
+Emitted with `(message, handle)` when a message is received over the IPC channel. `handle` is the transferred `Pipe` or `Socket`, or `null` if none was sent.
+
+#### `event: 'disconnect'`
+
+Emitted when the IPC channel has been fully closed.
+
+#### `event: 'error'`
+
+Emitted when an error occurs on the IPC channel, such as a malformed message or a pipe-level failure. The error has a `code` property; for parse errors the code is `'INVALID_MESSAGE'` and the original error is available on `err.cause`.
+
+### `class SubprocessParentChannel`
+
+Available as `require('bare-subprocess/parent')`. Constructed by the child process to access the parent end of the IPC channel. The serialization mode is selected automatically from the `BARE_CHANNEL_SERIALIZATION_MODE` environment variable, which is set by `spawn` in the parent.
+
+```js
+const ParentChannel = require('bare-subprocess/parent')
+
+const parent = new ParentChannel()
+
+parent.on('message', (message, handle) => {
+  parent.send({ echoed: message })
+})
+```
+
+#### `parent.connected`
+
+`true` while the channel is open.
+
+#### `parent.send(message[, handle][, callback])`
+
+Same semantics as the corresponding `Subprocess` method.
+
+#### `parent.disconnect()`
+
+Same semantics as the corresponding `Subprocess` method.
+
+#### `parent.ref()`
+
+Same semantics as the corresponding `Subprocess` method.
+
+#### `parent.unref()`
+
+Same semantics as the corresponding `Subprocess` method.
+
+#### `event: 'message'`
+
+Same semantics as the corresponding `Subprocess` event.
+
+#### `event: 'disconnect'`
+
+Same semantics as the corresponding `Subprocess` event.
+
+#### `event: 'error'`
+
+Same semantics as the corresponding `Subprocess` event.
+
+### `constants`
+
+Re-exports the signal constants from `bare-os` (i.e. `os.constants.signals`). Also available as `require('bare-subprocess/constants')`.
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ export interface SubprocessEvents extends EventMap {
   exit: [code: number | null, signalCode: string | null]
   message: [message: unknown, handle: unknown]
   disconnect: []
+  error: [err: Error]
 }
 
 export type IO = 'inherit' | 'pipe' | 'overlapped' | 'ignore' | 'ipc'

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import SubprocessChannel from './lib/channel'
 import constants from './lib/constants'
 import errors from './lib/errors'
 
-export { constants, errors, SubprocessChannel }
+export { constants, errors, type SubprocessChannel }
 
 export interface SubprocessEvents extends EventMap {
   exit: [code: number | null, signalCode: string | null]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,19 @@
 import EventEmitter, { EventMap } from 'bare-events'
 import Buffer from 'bare-buffer'
 import Pipe from 'bare-pipe'
+import SubprocessChannel from './lib/channel'
 import constants from './lib/constants'
 import errors from './lib/errors'
 
-export { constants, errors }
+export { constants, errors, SubprocessChannel }
 
 export interface SubprocessEvents extends EventMap {
   exit: [code: number | null, signalCode: string | null]
+  message: [message: unknown, handle: unknown]
+  disconnect: []
 }
 
-export type IO = 'inherit' | 'pipe' | 'overlapped' | 'ignore'
+export type IO = 'inherit' | 'pipe' | 'overlapped' | 'ignore' | 'ipc'
 
 export interface Subprocess<M extends SubprocessEvents = SubprocessEvents> extends EventEmitter<M> {
   readonly exitCode: number | null
@@ -23,14 +26,23 @@ export interface Subprocess<M extends SubprocessEvents = SubprocessEvents> exten
   readonly stdin: Pipe | null
   readonly stdout: Pipe | null
   readonly stderr: Pipe | null
+  readonly channel?: SubprocessChannel
+  readonly connected: boolean
 
   ref(): void
   unref(): void
 
   kill(signum?: number): void
+
+  send(message: unknown, handle?: unknown, cb?: (err: Error | null) => void): boolean
+  send(message: unknown, cb: (err: Error | null) => void): boolean
+
+  disconnect(): void
 }
 
 export class Subprocess {}
+
+export type SerializationMode = 'json' | 'advanced' | 'binary'
 
 export interface SpawnOptions {
   cwd?: string
@@ -42,6 +54,7 @@ export interface SpawnOptions {
   env?: Record<string, string>
   windowsHide?: boolean
   windowsVerbatimArguments?: boolean
+  serialization?: SerializationMode
 }
 
 export function spawn(file: string, args?: string[] | null, opts?: SpawnOptions): Subprocess

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ exports.Subprocess = class Subprocess extends EventEmitter {
     this.killed = true
   }
 
-  send(message, handle, cb) {
+  send(message, handle = null, cb) {
     if (typeof handle === 'function') {
       cb = handle
       handle = null

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ const os = require('bare-os')
 const env = require('bare-env')
 const { isURL, fileURLToPath } = require('bare-url')
 const binding = require('./binding')
+const Channel = require('./lib/channel')
+const JSONFramer = require('./lib/framers/json')
+const AdvancedFramer = require('./lib/framers/advanced')
 const constants = require('./lib/constants')
 const errors = require('./lib/errors')
 
@@ -18,36 +21,14 @@ exports.Subprocess = class Subprocess extends EventEmitter {
     this.exitCode = null
     this.signalCode = null
     this.killed = false
+    this.channel = undefined
 
     this._closing = []
     this._handle = binding.init(this, this._onexit)
   }
 
-  _flush() {
-    for (const pipe of this.stdio) {
-      if (pipe && typeof pipe.resume === 'function') pipe.resume()
-    }
-  }
-
-  async _onexit(code, signal) {
-    if (signal) {
-      for (const [name, val] of Object.entries(os.constants.signals)) {
-        if (signal === val) {
-          this.signalCode = name
-          break
-        }
-      }
-    } else {
-      this.exitCode = code
-    }
-
-    this.emit('exit', this.exitCode, this.signalCode)
-
-    queueMicrotask(this._flush.bind(this)) // Defer to provide a last chance to consume
-
-    await Promise.all(this._closing)
-
-    this.emit('close', this.exitCode, this.signalCode)
+  get connected() {
+    return this.channel !== undefined
   }
 
   get stdin() {
@@ -91,6 +72,53 @@ exports.Subprocess = class Subprocess extends EventEmitter {
 
     this.killed = true
   }
+
+  send(message, handle, cb) {
+    if (typeof handle === 'function') {
+      cb = handle
+      handle = null
+    }
+
+    if (this.channel === undefined) {
+      const err = errors.NO_IPC_CHANNEL('Subprocess has no IPC channel')
+      if (cb) queueMicrotask(() => cb(err))
+      return false
+    }
+
+    return this.channel.send(message, handle, cb)
+  }
+
+  disconnect() {
+    if (this.channel === undefined) return
+    this.channel.disconnect()
+  }
+
+  _flush() {
+    for (const pipe of this.stdio) {
+      if (pipe && typeof pipe.resume === 'function') pipe.resume()
+    }
+  }
+
+  async _onexit(code, signal) {
+    if (signal) {
+      for (const [name, val] of Object.entries(os.constants.signals)) {
+        if (signal === val) {
+          this.signalCode = name
+          break
+        }
+      }
+    } else {
+      this.exitCode = code
+    }
+
+    this.emit('exit', this.exitCode, this.signalCode)
+
+    queueMicrotask(this._flush.bind(this)) // Defer to provide a last chance to consume
+
+    await Promise.all(this._closing)
+
+    this.emit('close', this.exitCode, this.signalCode)
+  }
 }
 
 exports.ChildProcess = exports.Subprocess // For Node.js compatibility
@@ -121,8 +149,13 @@ exports.spawn = function spawn(file, args, opts) {
     uid = -1,
     gid = -1,
     windowsHide = false,
-    windowsVerbatimArguments = false
+    windowsVerbatimArguments = false,
+    serialization = 'json'
   } = opts
+
+  if (serialization !== 'json' && serialization !== 'advanced' && serialization !== 'binary') {
+    throw errors.UNKNOWN_SERIALIZATION_MODE(`Unknown serialization mode '${serialization}'`)
+  }
 
   file = toPath(file)
   cwd = toPath(cwd)
@@ -175,6 +208,8 @@ exports.spawn = function spawn(file, args, opts) {
   subprocess.spawnfile = file
   subprocess.spawnargs = args
 
+  let ipcSlot = -1
+
   for (let i = 0, n = Math.max(3, stdio.length); i < n; i++) {
     subprocess.stdio[i] = null
 
@@ -200,9 +235,31 @@ exports.spawn = function spawn(file, args, opts) {
       stdio[i] = { flags, pipe: pipe._handle }
 
       subprocess.stdio[i] = pipe
+    } else if (fd === 'ipc') {
+      if (ipcSlot !== -1) {
+        throw errors.IPC_CHANNEL_ALREADY_DEFINED('Only one IPC channel per subprocess')
+      }
+
+      ipcSlot = i
+
+      const pipe = new Pipe({ ipc: true })
+
+      pipe._onspawn(true, true)
+
+      subprocess._closing.push(new Promise((resolve) => pipe.once('close', resolve)))
+
+      const flags = binding.UV_CREATE_PIPE | binding.UV_READABLE_PIPE | binding.UV_WRITABLE_PIPE
+
+      stdio[i] = { flags, pipe: pipe._handle }
+
+      subprocess.stdio[i] = pipe
     } else {
       stdio[i] = { flags: binding.UV_INHERIT_FD, fd }
     }
+  }
+
+  if (ipcSlot !== -1) {
+    pairs.push(`BARE_CHANNEL_FD=${ipcSlot}`, `BARE_CHANNEL_SERIALIZATION_MODE=${serialization}`)
   }
 
   subprocess.pid = binding.spawn(
@@ -218,6 +275,22 @@ exports.spawn = function spawn(file, args, opts) {
     windowsHide,
     windowsVerbatimArguments
   )
+
+  if (ipcSlot !== -1 && serialization !== 'binary') {
+    let framer
+
+    if (serialization === 'json') {
+      framer = new JSONFramer()
+    } else if (serialization === 'advanced') {
+      framer = new AdvancedFramer()
+    }
+
+    subprocess.channel = new Channel(subprocess, subprocess.stdio[ipcSlot], framer)
+
+    subprocess.once('disconnect', () => {
+      subprocess.channel = undefined
+    })
+  }
 
   return subprocess
 }

--- a/lib/channel.d.ts
+++ b/lib/channel.d.ts
@@ -1,0 +1,13 @@
+interface SubprocessChannel {
+  readonly connected: boolean
+
+  send(message: unknown, handle?: unknown, cb?: (err: Error | null) => void): boolean
+  send(message: unknown, cb: (err: Error | null) => void): boolean
+
+  disconnect(): void
+
+  ref(): this
+  unref(): this
+}
+
+export = SubprocessChannel

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -24,7 +24,7 @@ module.exports = class SubprocessChannel {
     return this._connected
   }
 
-  send(message, handle, cb) {
+  send(message, handle = null, cb) {
     if (typeof handle === 'function') {
       cb = handle
       handle = null
@@ -38,7 +38,7 @@ module.exports = class SubprocessChannel {
 
     const data = this._framer.encode({ message, hasHandle: handle !== null })
 
-    if (handle) return this._pipe.write(data, handle, cb)
+    if (handle !== null) return this._pipe.write(data, handle, cb)
     return this._pipe.write(data, cb)
   }
 

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -15,6 +15,7 @@ module.exports = class SubprocessChannel {
     pipe
       .on('data', this._ondata.bind(this))
       .on('handle', this._onhandle.bind(this))
+      .on('error', this._onerror.bind(this))
       .on('end', this._ondisconnect.bind(this))
       .on('close', this._ondisconnect.bind(this))
   }
@@ -70,7 +71,15 @@ module.exports = class SubprocessChannel {
   }
 
   _ondata(chunk) {
-    this._framer.push(chunk, this._onmessage)
+    try {
+      this._framer.push(chunk, this._onmessage)
+    } catch (err) {
+      this._subprocess.emit('error', err)
+    }
+  }
+
+  _onerror(err) {
+    this._subprocess.emit('error', err)
   }
 
   _onmessage(envelope) {

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -1,0 +1,87 @@
+const Pipe = require('bare-pipe')
+const { Socket } = require('bare-tcp')
+const errors = require('./errors')
+
+module.exports = class SubprocessChannel {
+  constructor(subprocess, pipe, framer) {
+    this._subprocess = subprocess
+    this._pipe = pipe
+    this._framer = framer
+    this._connected = true
+    this._pendingHandle = null
+
+    this._onmessage = this._onmessage.bind(this)
+
+    pipe
+      .on('data', this._ondata.bind(this))
+      .on('handle', this._onhandle.bind(this))
+      .on('end', this._ondisconnect.bind(this))
+      .on('close', this._ondisconnect.bind(this))
+  }
+
+  get connected() {
+    return this._connected
+  }
+
+  send(message, handle, cb) {
+    if (typeof handle === 'function') {
+      cb = handle
+      handle = null
+    }
+
+    if (this._connected === false) {
+      const err = errors.CHANNEL_DISCONNECTED('Channel is disconnected')
+      if (cb) queueMicrotask(() => cb(err))
+      return false
+    }
+
+    const data = this._framer.encode(message)
+
+    if (handle) return this._pipe.write(data, handle, cb)
+    return this._pipe.write(data, cb)
+  }
+
+  disconnect() {
+    if (this._connected === false) return
+    this._pipe.end()
+  }
+
+  ref() {
+    this._pipe.ref()
+    return this
+  }
+
+  unref() {
+    this._pipe.unref()
+    return this
+  }
+
+  _onhandle(type) {
+    let target
+
+    if (type === Pipe.constants.handle.NAMED_PIPE) {
+      target = new Pipe()
+    } else if (type === Pipe.constants.handle.TCP) {
+      target = new Socket()
+    } else return
+
+    this._pipe.accept(target)
+    this._pendingHandle = target
+  }
+
+  _ondata(chunk) {
+    this._framer.push(chunk, this._onmessage)
+  }
+
+  _onmessage(message) {
+    const handle = this._pendingHandle
+    this._pendingHandle = null
+    this._subprocess.emit('message', message, handle)
+  }
+
+  _ondisconnect() {
+    if (this._connected === false) return
+    this._connected = false
+    this._subprocess.emit('disconnect')
+  }
+}

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -8,7 +8,7 @@ module.exports = class SubprocessChannel {
     this._pipe = pipe
     this._framer = framer
     this._connected = true
-    this._pendingHandle = null
+    this._pendingHandles = []
 
     this._onmessage = this._onmessage.bind(this)
 
@@ -35,7 +35,7 @@ module.exports = class SubprocessChannel {
       return false
     }
 
-    const data = this._framer.encode(message)
+    const data = this._framer.encode({ message, hasHandle: handle !== null })
 
     if (handle) return this._pipe.write(data, handle, cb)
     return this._pipe.write(data, cb)
@@ -66,22 +66,26 @@ module.exports = class SubprocessChannel {
     } else return
 
     this._pipe.accept(target)
-    this._pendingHandle = target
+    this._pendingHandles.push(target)
   }
 
   _ondata(chunk) {
     this._framer.push(chunk, this._onmessage)
   }
 
-  _onmessage(message) {
-    const handle = this._pendingHandle
-    this._pendingHandle = null
+  _onmessage(envelope) {
+    const { message, hasHandle } = envelope
+    const handle = hasHandle ? this._pendingHandles.shift() || null : null
     this._subprocess.emit('message', message, handle)
   }
 
   _ondisconnect() {
     if (this._connected === false) return
     this._connected = false
+
+    for (const target of this._pendingHandles) target.destroy()
+    this._pendingHandles = []
+
     this._subprocess.emit('disconnect')
   }
 }

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -1,7 +1,5 @@
 declare class SubprocessError extends Error {
   readonly code: string
-
-  static UNKNOWN_SIGNAL(msg: string): SubprocessError
 }
 
 export = SubprocessError

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,6 +38,10 @@ module.exports = class SubprocessError extends Error {
     })
   }
 
+  static MESSAGE_TOO_LARGE(msg) {
+    return new SubprocessError(msg, 'MESSAGE_TOO_LARGE', SubprocessError.MESSAGE_TOO_LARGE)
+  }
+
   static UNKNOWN_SERIALIZATION_MODE(msg) {
     return new SubprocessError(
       msg,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 module.exports = class SubprocessError extends Error {
-  constructor(msg, code, fn = SubprocessError) {
-    super(`${code}: ${msg}`)
+  constructor(msg, code, fn = SubprocessError, opts) {
+    super(`${code}: ${msg}`, opts)
     this.code = code
 
     if (Error.captureStackTrace) {
@@ -14,5 +14,35 @@ module.exports = class SubprocessError extends Error {
 
   static UNKNOWN_SIGNAL(msg) {
     return new SubprocessError(msg, 'UNKNOWN_SIGNAL', SubprocessError.UNKNOWN_SIGNAL)
+  }
+
+  static IPC_CHANNEL_ALREADY_DEFINED(msg) {
+    return new SubprocessError(
+      msg,
+      'IPC_CHANNEL_ALREADY_DEFINED',
+      SubprocessError.IPC_CHANNEL_ALREADY_DEFINED
+    )
+  }
+
+  static NO_IPC_CHANNEL(msg) {
+    return new SubprocessError(msg, 'NO_IPC_CHANNEL', SubprocessError.NO_IPC_CHANNEL)
+  }
+
+  static CHANNEL_DISCONNECTED(msg) {
+    return new SubprocessError(msg, 'CHANNEL_DISCONNECTED', SubprocessError.CHANNEL_DISCONNECTED)
+  }
+
+  static INVALID_MESSAGE(msg, cause) {
+    return new SubprocessError(msg, 'INVALID_MESSAGE', SubprocessError.INVALID_MESSAGE, {
+      cause
+    })
+  }
+
+  static UNKNOWN_SERIALIZATION_MODE(msg) {
+    return new SubprocessError(
+      msg,
+      'UNKNOWN_SERIALIZATION_MODE',
+      SubprocessError.UNKNOWN_SERIALIZATION_MODE
+    )
   }
 }

--- a/lib/framers/advanced.js
+++ b/lib/framers/advanced.js
@@ -1,6 +1,8 @@
 const structuredClone = require('bare-structured-clone')
 const errors = require('../errors')
 
+const MAX_FRAME_SIZE = 0xffffffff
+
 module.exports = class SubprocessAdvancedFramer {
   constructor() {
     this._buffer = []
@@ -17,9 +19,9 @@ module.exports = class SubprocessAdvancedFramer {
 
     const bodyLength = state.end - 4
 
-    if (bodyLength > 0xffffffff) {
+    if (bodyLength > MAX_FRAME_SIZE) {
       throw errors.MESSAGE_TOO_LARGE(
-        `IPC message exceeds the maximum frame size of ${0xffffffff} bytes`
+        `IPC message exceeds the maximum frame size of ${MAX_FRAME_SIZE} bytes`
       )
     }
 

--- a/lib/framers/advanced.js
+++ b/lib/framers/advanced.js
@@ -1,0 +1,96 @@
+const structuredClone = require('bare-structured-clone')
+const errors = require('../errors')
+
+module.exports = class SubprocessAdvancedFramer {
+  constructor() {
+    this._buffer = []
+    this._buffered = 0
+    this._bodyLength = -1
+  }
+
+  encode(message) {
+    const serialized = structuredClone.serialize(message)
+
+    const state = { start: 0, end: 4, buffer: null }
+
+    structuredClone.preencode(state, serialized)
+
+    const frame = Buffer.alloc(state.end)
+    state.buffer = frame
+
+    frame.writeUInt32LE(frame.byteLength - 4, 0)
+    state.start += 4
+
+    structuredClone.encode(state, serialized)
+
+    return frame
+  }
+
+  push(chunk, onmessage) {
+    this._buffer.push(chunk)
+    this._buffered += chunk.byteLength
+
+    this._consume(onmessage)
+  }
+
+  _consume(onmessage) {
+    while (true) {
+      if (this._bodyLength === -1) {
+        if (this._buffered < 4) return
+
+        const header = this._read(4)
+        this._bodyLength = header.readUInt32LE(0)
+      }
+
+      if (this._buffered < this._bodyLength) return
+
+      const body = this._read(this._bodyLength)
+      this._bodyLength = -1
+
+      let message
+      try {
+        const state = { start: 0, end: body.byteLength, buffer: body }
+
+        message = structuredClone.deserialize(structuredClone.decode(state))
+      } catch (err) {
+        throw errors.INVALID_MESSAGE('Invalid IPC message', err)
+      }
+
+      onmessage(message)
+    }
+  }
+
+  _read(n) {
+    this._buffered -= n
+
+    if (this._buffer[0].byteLength === n) {
+      return this._buffer.shift()
+    }
+
+    if (this._buffer[0].byteLength > n) {
+      const head = this._buffer[0]
+      this._buffer[0] = head.subarray(n)
+
+      return head.subarray(0, n)
+    }
+
+    const parts = []
+    let remaining = n
+
+    while (remaining > 0) {
+      const head = this._buffer[0]
+
+      if (head.byteLength <= remaining) {
+        parts.push(head)
+        remaining -= head.byteLength
+        this._buffer.shift()
+      } else {
+        parts.push(head.subarray(0, remaining))
+        this._buffer[0] = head.subarray(remaining)
+        remaining = 0
+      }
+    }
+
+    return Buffer.concat(parts)
+  }
+}

--- a/lib/framers/advanced.js
+++ b/lib/framers/advanced.js
@@ -15,10 +15,18 @@ module.exports = class SubprocessAdvancedFramer {
 
     structuredClone.preencode(state, serialized)
 
+    const bodyLength = state.end - 4
+
+    if (bodyLength > 0xffffffff) {
+      throw errors.MESSAGE_TOO_LARGE(
+        `IPC message exceeds the maximum frame size of ${0xffffffff} bytes`
+      )
+    }
+
     const frame = Buffer.alloc(state.end)
     state.buffer = frame
 
-    frame.writeUInt32LE(frame.byteLength - 4, 0)
+    frame.writeUInt32LE(bodyLength, 0)
     state.start += 4
 
     structuredClone.encode(state, serialized)

--- a/lib/framers/json.js
+++ b/lib/framers/json.js
@@ -1,0 +1,70 @@
+const errors = require('../errors')
+
+module.exports = class SubprocessJSONFramer {
+  constructor() {
+    this._buffer = []
+    this._buffered = 0
+  }
+
+  encode(message) {
+    return Buffer.from(JSON.stringify(message) + '\n')
+  }
+
+  push(chunk, onmessage) {
+    this._buffer.push(chunk)
+    this._buffered += chunk.byteLength
+
+    if (chunk.indexOf(0x0a /* \n */) === -1) return
+
+    this._consume(onmessage)
+  }
+
+  _consume(onmessage) {
+    while (true) {
+      let bufferIdx = -1
+      let byteIdx = -1
+      let offset = 0
+
+      for (let i = 0; i < this._buffer.length; i++) {
+        const idx = this._buffer[i].indexOf(0x0a /* \n */)
+
+        if (idx !== -1) {
+          bufferIdx = i
+          byteIdx = idx
+          break
+        }
+
+        offset += this._buffer[i].byteLength
+      }
+
+      if (bufferIdx === -1) return
+
+      let line
+
+      if (bufferIdx === 0) {
+        line = this._buffer[0].subarray(0, byteIdx).toString('utf8')
+      } else {
+        const parts = []
+        for (let i = 0; i < bufferIdx; i++) parts.push(this._buffer[i])
+        parts.push(this._buffer[bufferIdx].subarray(0, byteIdx))
+
+        line = Buffer.concat(parts).toString('utf8')
+      }
+
+      this._buffered -= offset + byteIdx + 1
+
+      const remainder = this._buffer[bufferIdx].subarray(byteIdx + 1)
+      this._buffer.splice(0, bufferIdx + 1)
+      if (remainder.byteLength > 0) this._buffer.unshift(remainder)
+
+      let message
+      try {
+        message = JSON.parse(line)
+      } catch (err) {
+        throw errors.INVALID_MESSAGE('Invalid IPC message', err)
+      }
+
+      onmessage(message)
+    }
+  }
+}

--- a/lib/framers/json.js
+++ b/lib/framers/json.js
@@ -1,5 +1,7 @@
 const errors = require('../errors')
 
+const MAX_FRAME_SIZE = 0xffffffff
+
 module.exports = class SubprocessJSONFramer {
   constructor() {
     this._buffer = []
@@ -14,9 +16,15 @@ module.exports = class SubprocessJSONFramer {
     this._buffer.push(chunk)
     this._buffered += chunk.byteLength
 
-    if (chunk.indexOf(0x0a /* \n */) === -1) return
+    if (chunk.indexOf(0x0a /* \n */) !== -1) {
+      this._consume(onmessage)
+    }
 
-    this._consume(onmessage)
+    if (this._buffered > MAX_FRAME_SIZE) {
+      throw errors.MESSAGE_TOO_LARGE(
+        `IPC message exceeds the maximum frame size of ${MAX_FRAME_SIZE} bytes`
+      )
+    }
   }
 
   _consume(onmessage) {
@@ -39,6 +47,14 @@ module.exports = class SubprocessJSONFramer {
 
       if (bufferIdx === -1) return
 
+      const lineLength = offset + byteIdx
+
+      if (lineLength > MAX_FRAME_SIZE) {
+        throw errors.MESSAGE_TOO_LARGE(
+          `IPC message exceeds the maximum frame size of ${MAX_FRAME_SIZE} bytes`
+        )
+      }
+
       let line
 
       if (bufferIdx === 0) {
@@ -51,7 +67,7 @@ module.exports = class SubprocessJSONFramer {
         line = Buffer.concat(parts).toString('utf8')
       }
 
-      this._buffered -= offset + byteIdx + 1
+      this._buffered -= lineLength + 1
 
       const remainder = this._buffer[bufferIdx].subarray(byteIdx + 1)
       this._buffer.splice(0, bufferIdx + 1)

--- a/lib/parent.d.ts
+++ b/lib/parent.d.ts
@@ -3,6 +3,7 @@ import EventEmitter, { EventMap } from 'bare-events'
 interface SubprocessParentChannelEvents extends EventMap {
   message: [message: unknown, handle: unknown]
   disconnect: []
+  error: [err: Error]
 }
 
 interface SubprocessParentChannel<

--- a/lib/parent.d.ts
+++ b/lib/parent.d.ts
@@ -1,0 +1,28 @@
+import EventEmitter, { EventMap } from 'bare-events'
+
+interface SubprocessParentChannelEvents extends EventMap {
+  message: [message: unknown, handle: unknown]
+  disconnect: []
+}
+
+interface SubprocessParentChannel<
+  M extends SubprocessParentChannelEvents = SubprocessParentChannelEvents
+> extends EventEmitter<M> {
+  readonly connected: boolean
+
+  send(message: unknown, handle?: unknown, cb?: (err: Error | null) => void): boolean
+  send(message: unknown, cb: (err: Error | null) => void): boolean
+
+  disconnect(): void
+
+  ref(): this
+  unref(): this
+}
+
+declare class SubprocessParentChannel<
+  M extends SubprocessParentChannelEvents = SubprocessParentChannelEvents
+> {
+  constructor()
+}
+
+export = SubprocessParentChannel

--- a/lib/parent.js
+++ b/lib/parent.js
@@ -1,0 +1,56 @@
+const EventEmitter = require('bare-events')
+const Pipe = require('bare-pipe')
+const env = require('bare-env')
+const SubprocessChannel = require('./channel')
+const JSONFramer = require('./framers/json')
+const AdvancedFramer = require('./framers/advanced')
+const errors = require('./errors')
+
+module.exports = class SubprocessParentChannel extends EventEmitter {
+  constructor() {
+    super()
+
+    const fd = Number(env.BARE_CHANNEL_FD)
+
+    if (!Number.isFinite(fd)) {
+      throw errors.NO_IPC_CHANNEL('BARE_CHANNEL_FD is not set')
+    }
+
+    const serialization = env.BARE_CHANNEL_SERIALIZATION_MODE || 'json'
+
+    let framer
+
+    if (serialization === 'json') {
+      framer = new JSONFramer()
+    } else if (serialization === 'advanced') {
+      framer = new AdvancedFramer()
+    } else {
+      throw errors.UNKNOWN_SERIALIZATION_MODE(`Unknown serialization mode '${serialization}'`)
+    }
+
+    this._pipe = new Pipe(fd, { ipc: true })
+    this._channel = new SubprocessChannel(this, this._pipe, framer)
+  }
+
+  get connected() {
+    return this._channel.connected
+  }
+
+  send(message, handle, cb) {
+    return this._channel.send(message, handle, cb)
+  }
+
+  disconnect() {
+    this._channel.disconnect()
+  }
+
+  ref() {
+    this._channel.ref()
+    return this
+  }
+
+  unref() {
+    this._channel.unref()
+    return this
+  }
+}

--- a/lib/parent.js
+++ b/lib/parent.js
@@ -36,7 +36,7 @@ module.exports = class SubprocessParentChannel extends EventEmitter {
     return this._channel.connected
   }
 
-  send(message, handle, cb) {
+  send(message, handle = null, cb) {
     return this._channel.send(message, handle, cb)
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "./errors": {
       "types": "./lib/errors.d.ts",
       "default": "./lib/errors.js"
+    },
+    "./parent": {
+      "types": "./lib/parent.d.ts",
+      "default": "./lib/parent.js"
     }
   },
   "files": [
@@ -50,6 +54,7 @@
     "bare-events": "^2.5.4",
     "bare-os": "^3.0.1",
     "bare-pipe": "^4.0.0",
+    "bare-structured-clone": "^1.5.2",
     "bare-url": "^2.2.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,9 @@
     "bare-env": "^3.0.0",
     "bare-events": "^2.5.4",
     "bare-os": "^3.0.1",
-    "bare-pipe": "^4.0.0",
+    "bare-pipe": "^4.2.0",
     "bare-structured-clone": "^1.5.2",
+    "bare-tcp": "^2.4.1",
     "bare-url": "^2.2.2"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -308,12 +308,15 @@ test('ipc, send multiple handles interleaved with plain messages', async (t) => 
   let plainReceived = false
 
   server.on('connection', (sock) => {
+    let buffer = Buffer.alloc(0)
+
     sock.on('data', (data) => {
-      const label = data.toString('utf8', 4, 5)
-      received[label] = Buffer.concat([received[label], data])
+      buffer = Buffer.concat([buffer, data])
     })
 
     sock.on('end', () => {
+      const label = buffer.toString('utf8', 4, 5)
+      received[label] = buffer
       sock.destroy()
       closedSockets++
       if (closedSockets === 2 && plainReceived) finish()

--- a/test.js
+++ b/test.js
@@ -242,6 +242,20 @@ test('ipc, binary serialization', (t) => {
   pipe.write(Buffer.from('hello'))
 })
 
+test('ipc, malformed message', (t) => {
+  t.plan(2)
+
+  const subprocess = spawn(os.execPath(), ['test/fixtures/ipc-garbage.js'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  })
+
+  subprocess.on('error', (err) => {
+    t.is(err.code, 'INVALID_MESSAGE')
+    t.ok(err.cause instanceof Error)
+    subprocess.kill()
+  })
+})
+
 test('ipc, send handle', async (t) => {
   t.plan(1)
 

--- a/test.js
+++ b/test.js
@@ -312,9 +312,9 @@ test('ipc, send multiple handles interleaved with plain messages', async (t) => 
 
     sock.on('data', (data) => {
       buffer = Buffer.concat([buffer, data])
-    })
 
-    sock.on('end', () => {
+      if (buffer.length < 5) return
+
       const label = buffer.toString('utf8', 4, 5)
       received[label] = buffer
       sock.destroy()

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ const test = require('brittle')
 const fs = require('bare-fs')
 const os = require('bare-os')
 const path = require('bare-path')
+const tcp = require('bare-tcp')
 const { spawn, spawnSync } = require('.')
 
 test('basic', (t) => {
@@ -159,6 +160,126 @@ test('long path', { skip: Bare.platform === 'win32' }, (t) => {
   subprocess.stdout.on('data', (data) => t.alike(data, Buffer.from('hello' + os.EOL)))
 
   subprocess.stderr.on('data', (err) => t.fail(err.toString()))
+})
+
+test('ipc, receive', (t) => {
+  t.plan(1)
+
+  const subprocess = spawn(os.execPath(), ['test/fixtures/ipc.js'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  })
+
+  subprocess.on('message', (message) => {
+    t.alike(message, { hello: 'world' })
+    subprocess.kill()
+  })
+})
+
+test('ipc, send + receive', (t) => {
+  t.plan(2)
+
+  const subprocess = spawn(os.execPath(), ['test/fixtures/ipc.js'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  })
+
+  let received = 0
+
+  subprocess.on('message', (message) => {
+    received++
+
+    if (received === 1) {
+      t.alike(message, { hello: 'world' })
+      subprocess.send({ ping: 42 })
+    } else {
+      t.alike(message, { echoed: { ping: 42 } })
+      subprocess.kill()
+    }
+  })
+})
+
+test('ipc, advanced serialization', (t) => {
+  t.plan(2)
+
+  const subprocess = spawn(os.execPath(), ['test/fixtures/ipc.js'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    serialization: 'advanced'
+  })
+
+  const date = new Date('2026-01-01T00:00:00Z')
+
+  let received = 0
+
+  subprocess.on('message', (message) => {
+    received++
+
+    if (received === 1) {
+      t.alike(message, { hello: 'world' })
+      subprocess.send({ ts: date })
+    } else {
+      t.alike(message, { echoed: { ts: date } })
+      subprocess.kill()
+    }
+  })
+})
+
+test('ipc, binary serialization', (t) => {
+  t.plan(2)
+
+  const subprocess = spawn(os.execPath(), ['test/fixtures/ipc-binary.js'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    serialization: 'binary'
+  })
+
+  t.is(subprocess.channel, undefined)
+
+  const pipe = subprocess.stdio[3]
+
+  pipe.on('data', (chunk) => {
+    t.alike(chunk, Buffer.from('echo:hello'))
+    subprocess.kill()
+  })
+
+  pipe.write(Buffer.from('hello'))
+})
+
+test('ipc, send handle', async (t) => {
+  t.plan(1)
+
+  let subprocess, peer
+
+  const server = tcp.createServer()
+
+  server.on('connection', (sock) => {
+    let received = Buffer.alloc(0)
+
+    sock.on('data', (data) => {
+      received = Buffer.concat([received, data])
+
+      if (received.length >= 16) {
+        t.alike(received, Buffer.from('hello from child'))
+
+        sock.destroy()
+        peer.destroy()
+        server.close()
+        subprocess.kill()
+      }
+    })
+  })
+
+  server.listen()
+  await new Promise((resolve) => server.on('listening', resolve))
+
+  const { port } = server.address()
+
+  subprocess = spawn(os.execPath(), ['test/fixtures/ipc-handle.js'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  })
+
+  peer = tcp.createConnection(port)
+
+  peer.on('connect', () => {
+    subprocess.send({ cmd: 'send' }, peer)
+  })
 })
 
 test('unref', (t) => {

--- a/test.js
+++ b/test.js
@@ -282,6 +282,72 @@ test('ipc, send handle', async (t) => {
   })
 })
 
+test('ipc, send multiple handles interleaved with plain messages', async (t) => {
+  t.plan(3)
+
+  let subprocess, peerA, peerB
+
+  const server = tcp.createServer()
+
+  const received = { A: Buffer.alloc(0), B: Buffer.alloc(0) }
+  let closedSockets = 0
+  let plainReceived = false
+
+  server.on('connection', (sock) => {
+    sock.on('data', (data) => {
+      const label = data.toString('utf8', 4, 5)
+      received[label] = Buffer.concat([received[label], data])
+    })
+
+    sock.on('end', () => {
+      sock.destroy()
+      closedSockets++
+      if (closedSockets === 2 && plainReceived) finish()
+    })
+  })
+
+  server.listen()
+  await new Promise((resolve) => server.on('listening', resolve))
+  const { port } = server.address()
+
+  subprocess = spawn(os.execPath(), ['test/fixtures/ipc-handles.js'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  })
+
+  subprocess.on('message', (message, handle) => {
+    if (message.plain && message.plain.note === 'no-handle') {
+      plainReceived = true
+      if (closedSockets === 2) finish()
+    }
+  })
+
+  let connected = 0
+  peerA = tcp.createConnection(port)
+  peerB = tcp.createConnection(port)
+
+  const onConnect = () => {
+    if (++connected < 2) return
+
+    subprocess.send({ id: 'A' }, peerA)
+    subprocess.send({ note: 'no-handle' })
+    subprocess.send({ id: 'B' }, peerB)
+  }
+
+  peerA.on('connect', onConnect)
+  peerB.on('connect', onConnect)
+
+  function finish() {
+    t.alike(received.A, Buffer.from('got:A'), 'first handle received message A')
+    t.alike(received.B, Buffer.from('got:B'), 'second handle received message B')
+    t.pass('plain message routed correctly')
+
+    peerA.destroy()
+    peerB.destroy()
+    server.close()
+    subprocess.kill()
+  }
+})
+
 test('unref', (t) => {
   t.plan(1)
 

--- a/test/fixtures/ipc-binary.js
+++ b/test/fixtures/ipc-binary.js
@@ -1,0 +1,8 @@
+const Pipe = require('bare-pipe')
+const env = require('bare-env')
+
+const pipe = new Pipe(Number(env.BARE_CHANNEL_FD), { ipc: true })
+
+pipe.on('data', (chunk) => {
+  pipe.write(Buffer.concat([Buffer.from('echo:'), chunk]))
+})

--- a/test/fixtures/ipc-garbage.js
+++ b/test/fixtures/ipc-garbage.js
@@ -1,0 +1,8 @@
+const Pipe = require('bare-pipe')
+const env = require('bare-env')
+
+const pipe = new Pipe(Number(env.BARE_CHANNEL_FD), { ipc: true })
+
+pipe.on('data', () => {})
+
+pipe.write(Buffer.from('not json\n'))

--- a/test/fixtures/ipc-handle.js
+++ b/test/fixtures/ipc-handle.js
@@ -1,0 +1,10 @@
+const ParentChannel = require('bare-subprocess/parent')
+
+const parent = new ParentChannel()
+
+parent.on('message', (message, handle) => {
+  if (message.cmd === 'send' && handle !== null) {
+    handle.write('hello from child')
+    handle.end()
+  }
+})

--- a/test/fixtures/ipc-handles.js
+++ b/test/fixtures/ipc-handles.js
@@ -1,0 +1,12 @@
+const ParentChannel = require('bare-subprocess/parent')
+
+const parent = new ParentChannel()
+
+parent.on('message', (message, handle) => {
+  if (handle === null) {
+    parent.send({ plain: message })
+  } else {
+    handle.write('got:' + message.id)
+    handle.end()
+  }
+})

--- a/test/fixtures/ipc.js
+++ b/test/fixtures/ipc.js
@@ -1,0 +1,9 @@
+const ParentChannel = require('bare-subprocess/parent')
+
+const parent = new ParentChannel()
+
+parent.send({ hello: 'world' })
+
+parent.on('message', (message) => {
+  parent.send({ echoed: message })
+})


### PR DESCRIPTION
- [x] https://github.com/holepunchto/bare-pipe/pull/22

This adds support for the same IPC API as `node:child_process` with an additional `'binary'` serialization mode that exposes the raw IPC pipe. When IPC is enabled `BARE_CHANNEL_FD` and `BARE_CHANNEL_SERIALIZATION_MODE` are passed to the spawned process so it can set up its own end of the pipe accordingly.